### PR TITLE
Fix for right EPG entry selection

### DIFF
--- a/custom_components/liveboxtvuhd/const_france.py
+++ b/custom_components/liveboxtvuhd/const_france.py
@@ -2,6 +2,8 @@
 EPG_URL = 'https://rp-ott-mediation-tv.woopic.com/api-gw/live/v3/applications/STB4PC/programs'
 EPG_USER_AGENT = "Opera/9.80 (Linux i686; U; fr) Presto/2.10.287 Version/12.00 ; SC/IHD92 STB"
 
+TIMEZONE="Europe/Paris"
+
 # channels
 CHANNELS = [
     {"index": "-1",  "epg_id": "-1",   "name": "N/A"},

--- a/custom_components/liveboxtvuhd/const_poland.py
+++ b/custom_components/liveboxtvuhd/const_poland.py
@@ -6,6 +6,8 @@ EPG_USER_AGENT = "Opera/9.80 (Linux i686; U; fr) Presto/2.10.287 Version/12.00 ;
 # epg: https://tvgo.orange.pl/gpapi/epg/epg?hhTech=&deviceCat=otg&chosen-day=1642287660
 # image: https://tvgo.orange.pl/mnapi/epgimages/akpah3154182.jpg
 
+TIMEZONE="Poland"
+
 CHANNELS = [
     {"index": "-1",  "epg_id": "-1",   "name": "N/A"},
     {"index": "0",  "epg_id": "0",   "name": "Mozajka"},


### PR DESCRIPTION
Hi,

I have added a method to extract the right EPG entry on French EPG : indeed several entries are returned and the right one has to be extracted according to start time + duration against current time